### PR TITLE
feat(snsqs): allow client http configuration for sns and sqs

### DIFF
--- a/pkg/sns/SnsConnectionFactory.php
+++ b/pkg/sns/SnsConnectionFactory.php
@@ -105,6 +105,10 @@ class SnsConnectionFactory implements ConnectionFactory
             }
         }
 
+        if (isset($this->config['http'])) {
+            $config['http'] = $this->config['http'];
+        }
+
         $establishConnection = function () use ($config) {
             return (new Sdk(['Sns' => $config]))->createMultiRegionSns();
         };
@@ -134,6 +138,7 @@ class SnsConnectionFactory implements ConnectionFactory
             'lazy' => $dsn->getBool('lazy'),
             'endpoint' => $dsn->getString('endpoint'),
             'topic_arns' => $dsn->getArray('topic_arns', [])->toArray(),
+            'http' => $dsn->getArray('http', [])->toArray(),
         ]), function ($value) { return null !== $value; });
     }
 
@@ -148,6 +153,7 @@ class SnsConnectionFactory implements ConnectionFactory
             'lazy' => true,
             'endpoint' => null,
             'topic_arns' => [],
+            'http' => [],
         ];
     }
 }

--- a/pkg/sns/Tests/SnsConnectionFactoryConfigTest.php
+++ b/pkg/sns/Tests/SnsConnectionFactoryConfigTest.php
@@ -65,6 +65,7 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'lazy' => true,
                 'endpoint' => null,
                 'topic_arns' => [],
+                'http' => [],
             ],
         ];
 
@@ -79,6 +80,7 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'lazy' => true,
                 'endpoint' => null,
                 'topic_arns' => [],
+                'http' => [],
             ],
         ];
 
@@ -93,6 +95,7 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'lazy' => true,
                 'endpoint' => null,
                 'topic_arns' => [],
+                'http' => [],
             ],
         ];
 
@@ -107,6 +110,7 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'lazy' => false,
                 'endpoint' => null,
                 'topic_arns' => [],
+                'http' => [],
             ],
         ];
 
@@ -121,6 +125,7 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'lazy' => false,
                 'endpoint' => null,
                 'topic_arns' => [],
+                'http' => [],
             ],
         ];
 
@@ -135,6 +140,7 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'lazy' => false,
                 'endpoint' => null,
                 'topic_arns' => [],
+                'http' => [],
             ],
         ];
 
@@ -155,6 +161,7 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'lazy' => false,
                 'endpoint' => 'http://localstack:1111',
                 'topic_arns' => [],
+                'http' => [],
             ],
         ];
 
@@ -171,6 +178,25 @@ class SnsConnectionFactoryConfigTest extends TestCase
                 'topic_arns' => [
                     'topic1' => 'arn:aws:sns:us-east-1:123456789012:topic1',
                     'topic2' => 'arn:aws:sns:us-west-2:123456789012:topic2',
+                ],
+                'http' => [],
+            ],
+        ];
+
+        yield [
+            ['dsn' => 'sns:?http[timeout]=5&http[connect_timeout]=2'],
+            [
+                'key' => null,
+                'secret' => null,
+                'token' => null,
+                'region' => null,
+                'version' => '2010-03-31',
+                'lazy' => true,
+                'endpoint' => null,
+                'topic_arns' => [],
+                'http' => [
+                    'timeout' => '5',
+                    'connect_timeout' => '2',
                 ],
             ],
         ];

--- a/pkg/sns/Tests/SnsConnectionFactoryTest.php
+++ b/pkg/sns/Tests/SnsConnectionFactoryTest.php
@@ -33,7 +33,8 @@ class SnsConnectionFactoryTest extends TestCase
             'region' => null,
             'version' => '2010-03-31',
             'endpoint' => null,
-             'topic_arns' => [],
+            'topic_arns' => [],
+            'http' => [],
         ], 'config', $factory);
     }
 
@@ -49,7 +50,8 @@ class SnsConnectionFactoryTest extends TestCase
             'region' => null,
             'version' => '2010-03-31',
             'endpoint' => null,
-             'topic_arns' => [],
+            'topic_arns' => [],
+            'http' => [],
         ], 'config', $factory);
     }
 

--- a/pkg/sqs/SqsConnectionFactory.php
+++ b/pkg/sqs/SqsConnectionFactory.php
@@ -108,6 +108,10 @@ class SqsConnectionFactory implements ConnectionFactory
             }
         }
 
+        if (isset($this->config['http'])) {
+            $config['http'] = $this->config['http'];
+        }
+
         $establishConnection = function () use ($config) {
             return (new Sdk(['Sqs' => $config]))->createMultiRegionSqs();
         };
@@ -139,6 +143,7 @@ class SqsConnectionFactory implements ConnectionFactory
             'endpoint' => $dsn->getString('endpoint'),
             'profile' => $dsn->getString('profile'),
             'queue_owner_aws_account_id' => $dsn->getString('queue_owner_aws_account_id'),
+            'http' => $dsn->getArray('http', [])->toArray(),
         ]), function ($value) { return null !== $value; });
     }
 
@@ -155,6 +160,7 @@ class SqsConnectionFactory implements ConnectionFactory
             'endpoint' => null,
             'profile' => null,
             'queue_owner_aws_account_id' => null,
+            'http' => [],
         ];
     }
 }

--- a/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryConfigTest.php
@@ -67,6 +67,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
+                'http' => [],
             ],
         ];
 
@@ -83,6 +84,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
+                'http' => [],
             ],
         ];
 
@@ -99,6 +101,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
+                'http' => [],
             ],
         ];
 
@@ -115,6 +118,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
+                'http' => [],
             ],
         ];
 
@@ -131,6 +135,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
+                'http' => [],
             ],
         ];
 
@@ -147,6 +152,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'endpoint' => null,
                 'profile' => 'staging',
                 'queue_owner_aws_account_id' => null,
+                'http' => [],
             ],
         ];
 
@@ -163,6 +169,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'endpoint' => null,
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
+                'http' => [],
             ],
         ];
 
@@ -185,6 +192,7 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'endpoint' => 'http://localstack:1111',
                 'profile' => null,
                 'queue_owner_aws_account_id' => null,
+                'http' => [],
             ],
         ];
 
@@ -203,6 +211,27 @@ class SqsConnectionFactoryConfigTest extends TestCase
                 'endpoint' => null,
                 'profile' => 'staging',
                 'queue_owner_aws_account_id' => null,
+                'http' => [],
+            ],
+        ];
+
+        yield [
+            ['dsn' => 'sqs:?http[timeout]=5&http[connect_timeout]=2'],
+            [
+                'key' => null,
+                'secret' => null,
+                'token' => null,
+                'region' => null,
+                'retries' => 3,
+                'version' => '2012-11-05',
+                'lazy' => true,
+                'endpoint' => null,
+                'profile' => null,
+                'queue_owner_aws_account_id' => null,
+                'http' => [
+                    'timeout' => '5',
+                    'connect_timeout' => '2',
+                ],
             ],
         ];
     }

--- a/pkg/sqs/Tests/SqsConnectionFactoryTest.php
+++ b/pkg/sqs/Tests/SqsConnectionFactoryTest.php
@@ -36,6 +36,7 @@ class SqsConnectionFactoryTest extends TestCase
             'endpoint' => null,
             'profile' => null,
             'queue_owner_aws_account_id' => null,
+            'http' => [],
         ], 'config', $factory);
     }
 
@@ -54,6 +55,7 @@ class SqsConnectionFactoryTest extends TestCase
             'endpoint' => null,
             'profile' => null,
             'queue_owner_aws_account_id' => null,
+            'http' => [],
         ], 'config', $factory);
     }
 


### PR DESCRIPTION
This changes allow to set in the AWS Sdk client the http configurations:
https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#config-http

This will make possible to define custom `connect_timeout` and
`timeout` to fail fast when the network is not relaible.

Reported on https://github.com/php-enqueue/enqueue-dev/issues/1213